### PR TITLE
Add support for Python 3

### DIFF
--- a/django_maven/management/commands/maven.py
+++ b/django_maven/management/commands/maven.py
@@ -42,7 +42,8 @@ class Command(BaseCommand):
 
     def run_from_argv(self, argv):
         if len(argv) <= 2 or argv[2] in ['-h', '--help']:
-            print self.usage(argv[1])
+            stdout = OutputWrapper(sys.stdout)
+            stdout.write(self.usage(argv[1]))
             sys.exit(1)
 
         subcommand_class = self._get_subcommand_class(argv[2])


### PR DESCRIPTION
Replaces "print" with appropriate call to sys.stdout.write. Similar to self.stdout.write available in BaseCommand.handle method.

Now "django_maven" works with Python 3 as well.

I think it's better than simply changing "print msg" to "print(msg)", since it behaves more like BaseCommand, which doesn't use "print".
