### PR TITLE
Support Django < v1.8 again

### DIFF
--- a/django_maven/management/commands/maven.py
+++ b/django_maven/management/commands/maven.py
@@ -35,13 +35,13 @@ class Command(BaseCommand):
             return usage
 
     def create_parser(self, prog_name, subcommand, subcommand_class):
-        if not self.use_argparse:
+        if hasattr(self, 'use_argparse') and self.use_argparse:
+            return super(Command, self).create_parser(prog_name, subcommand)
+        else:
             return OptionParser(prog=prog_name,
                                 usage=subcommand_class.usage(subcommand),
                                 version=subcommand_class.get_version(),
                                 option_list=subcommand_class.option_list)
-        else:
-            return super(Command, self).create_parser(prog_name, subcommand)
 
     def run_from_argv(self, argv):
         if len(argv) <= 2 or argv[2] in ['-h', '--help']:
@@ -50,7 +50,7 @@ class Command(BaseCommand):
 
         subcommand_class = self._get_subcommand_class(argv[2])
         parser = self.create_parser(argv[0], argv[2], subcommand_class)
-        if self.use_argparse:
+        if hasattr(self, 'use_argparse') and self.use_argparse:
             options = parser.parse_args(argv[3:])
             cmd_options = vars(options)
             args = cmd_options.pop('args', ())


### PR DESCRIPTION
Property use_argparse didn't exist in Django before v 1.8 - this commit should make django-maven support Django < 1.8 once more. See
https://github.com/saippuakauppias/django-maven/issues/7
