### PR TITLE
If sentry client turns out to be not enabled, raise the original exception

### DIFF
--- a/django_maven/management/commands/maven.py
+++ b/django_maven/management/commands/maven.py
@@ -68,6 +68,8 @@ class Command(BaseCommand):
                 else:
                     raise
                 sentry = Client(dsn)
+                if not sentry.is_enabled():
+                    raise
                 sentry.get_ident(sentry.captureException())
 
             self._write_error_in_stderr(e)


### PR DESCRIPTION
IMO, the case where the sentry client was created but is not enabled is equivalent to there being no SENTRY_DSN setting and no RAVEN_CONFIG setting (in which case the original exception is raised). 

The man command output will still include the info message "Raven is not configured (logging is disabled). Please see the documentation for more information.".

Our use case: We only log to sentry from staging and production, not from our local development instances (where we set SENTRY_DSN = ''). We want to be able to use the same cron.d file in all 3 places (ie. running "./manage.py maven our_man_command"), but if there's an uncaught exception in our_man_command when SENTRY_DSN='', we get an unhelpful TypeError from raven. This pull request means that we get to see the traceback detailing the exception in our_man_command instead. If this happens on staging or production, the info message mentioned above will alert us to the fact that sentry/raven is not configured and we can act accordingly.
