### PR TITLE
Support custom command line options in Django 1.8

### DIFF
--- a/django_maven/management/commands/maven.py
+++ b/django_maven/management/commands/maven.py
@@ -4,7 +4,7 @@ from optparse import OptionParser
 from django.conf import settings
 from django.core.management import get_commands, load_command_class
 from django.core.management.base import (BaseCommand, handle_default_options,
-                                         CommandError)
+                                         CommandError, SystemCheckError)
 from django.db import connections
 
 

--- a/django_maven/management/commands/maven.py
+++ b/django_maven/management/commands/maven.py
@@ -5,6 +5,8 @@ from django.conf import settings
 from django.core.management import get_commands, load_command_class
 from django.core.management.base import (BaseCommand, handle_default_options,
                                          CommandError)
+from django.db import connections
+
 
 from raven import Client
 from raven.transport.requests import RequestsHTTPTransport
@@ -22,47 +24,28 @@ class Command(BaseCommand):
         app_name = commands[command]
         return load_command_class(app_name, command)
 
-    def _write_error_in_stderr(self, exc):
-        stderr = getattr(self, 'stderr', OutputWrapper(sys.stderr,
-                                                       self.style.ERROR))
-        stderr.write('%s: %s' % (exc.__class__.__name__, exc))
-        sys.exit(1)
-
-    def usage(self, subcommand):
-        usage = 'Usage: %s %s [command options]' % (subcommand, self.args)
-        if self.help:
-            return '%s\n\n%s' % (usage, self.help)
-        else:
-            return usage
-
-    def create_parser(self, prog_name, subcommand, subcommand_class):
-        if hasattr(self, 'use_argparse') and self.use_argparse:
-            return super(Command, self).create_parser(prog_name, subcommand)
-        else:
-            return OptionParser(prog=prog_name,
-                                usage=subcommand_class.usage(subcommand),
-                                version=subcommand_class.get_version(),
-                                option_list=subcommand_class.option_list)
-
     def run_from_argv(self, argv):
+        """ Modified version of parent class to send errors in the command to Sentry.
+        """
         if len(argv) <= 2 or argv[2] in ['-h', '--help']:
             print self.usage(argv[1])
             sys.exit(1)
 
         subcommand_class = self._get_subcommand_class(argv[2])
-        parser = self.create_parser(argv[0], argv[2], subcommand_class)
-        if hasattr(self, 'use_argparse') and self.use_argparse:
-            subcommand_class.add_arguments(parser)
-            options = parser.parse_args(argv[3:])
-            cmd_options = vars(options)
-            args = cmd_options.pop('args', ())
-        else:
-            options, args = parser.parse_args(argv[3:])
+        parser = self.create_parser(argv[0], argv[2])
+        subcommand_class.add_arguments(parser)
+        options = parser.parse_args(argv[3:])
+        cmd_options = vars(options)
+        args = cmd_options.pop('args', ())
+            
+            
+        self._called_from_command_line = True
+
         handle_default_options(options)
         try:
-            subcommand_class.execute(*args, **options.__dict__)
+            subcommand_class.execute(*args, **cmd_options)
         except Exception as e:
-            if not isinstance(e, CommandError):
+            if options.traceback or not isinstance(e, CommandError):
                 if hasattr(settings, 'SENTRY_DSN'):
                     dsn = settings.SENTRY_DSN
                 elif hasattr(settings, 'RAVEN_CONFIG'):
@@ -72,5 +55,12 @@ class Command(BaseCommand):
                 # Force sync transport to avoid race condition with the process exiting
                 sentry = Client(dsn, transport=RequestsHTTPTransport)
                 sentry.get_ident(sentry.captureException())
-
-            self._write_error_in_stderr(e)
+                
+            # SystemCheckError takes care of its own formatting.
+            if isinstance(e, SystemCheckError):
+                self.stderr.write(str(e), lambda x: x)
+            else:
+                self.stderr.write('%s: %s' % (e.__class__.__name__, e))
+            sys.exit(1)
+        finally:
+            connections.close_all()

--- a/django_maven/management/commands/maven.py
+++ b/django_maven/management/commands/maven.py
@@ -7,7 +7,7 @@ from django.core.management.base import (BaseCommand, handle_default_options,
                                          CommandError)
 
 from raven import Client
-from raven.utils import urlparse
+from raven.transport.requests import RequestsHTTPTransport
 
 from django_maven.compat import OutputWrapper
 
@@ -69,12 +69,8 @@ class Command(BaseCommand):
                     dsn = settings.RAVEN_CONFIG.get('dsn')
                 else:
                     raise
-                sentry = Client(dsn)
                 # Force sync transport to avoid race condition with the process exiting
-                for url in sentry.servers:
-                    parsed = urlparse.urlparse(url)
-                    transport = sentry._registry.get_transport(parsed)
-                    transport.async = False
+                sentry = Client(dsn, transport=RequestsHTTPTransport)
                 sentry.get_ident(sentry.captureException())
 
             self._write_error_in_stderr(e)

--- a/django_maven/management/commands/maven.py
+++ b/django_maven/management/commands/maven.py
@@ -28,7 +28,7 @@ class Command(BaseCommand):
         """ Modified version of parent class to send errors in the command to Sentry.
         """
         if len(argv) <= 2 or argv[2] in ['-h', '--help']:
-            print self.usage(argv[1])
+            print(self.usage(argv[1]))
             sys.exit(1)
 
         subcommand_class = self._get_subcommand_class(argv[2])

--- a/django_maven/management/commands/maven.py
+++ b/django_maven/management/commands/maven.py
@@ -51,6 +51,7 @@ class Command(BaseCommand):
         subcommand_class = self._get_subcommand_class(argv[2])
         parser = self.create_parser(argv[0], argv[2], subcommand_class)
         if hasattr(self, 'use_argparse') and self.use_argparse:
+            subcommand_class.add_arguments(parser)
             options = parser.parse_args(argv[3:])
             cmd_options = vars(options)
             args = cmd_options.pop('args', ())


### PR DESCRIPTION
Django 1.8 commands are now supposed to use overridden add_arguments method on a command to add custom argument. These commands now get a chance to do that with Maven. Otherwise Maven can fail with "unrecognized arguments" error in the presence of custom arguments.
